### PR TITLE
fix landing page to larger screens - add bootstrap flex box to logo a…

### DIFF
--- a/app/assets/stylesheets/components/_landing_btns.scss
+++ b/app/assets/stylesheets/components/_landing_btns.scss
@@ -1,4 +1,4 @@
-.landing-btns {
-  margin-top: 240px;
-  margin-left: 580px;
-}
+// .landing-btns {
+//   margin-top: 240px;
+//   margin-left: 580px;
+// }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,33 +1,43 @@
 // Specific CSS for your home-page
 .home-container {
-  background-image: image-url('shared/home_background.jpg');
-  background-size: 100%;
-  height: 720px;
+  background: url('shared/home_background.jpg') no-repeat center center fixed;
+  background-size: cover;
+  height: 100vh;
+  min-height: 100vh;
+  min-height: 100%;
+  width: auto;
+  min-width: 1000px;
+  overflow: hidden;
+  position: relative;
 }
 
-.home-container img {
+.home-container .description {
+  flex-grow: 1;
+  position: absolute;
   height: 200px;
-  margin-left: 850px;
-  margin-top: 50px;
+  top: 50px;
+  right: 200px;
+  // margin-left: 850px;
+  // margin-top: 50px;
 }
 
-.home-container p {
-  color: #ffb7bc;
-  text-align: center;
-  font-size: 25px;
-  text-shadow: 1px 1px 1px white;
-}
+// .home-container p {
+//   color: #ffb7bc;
+//   text-align: center;
+//   font-size: 25px;
+//   text-shadow: 1px 1px 1px white;
+// }
 
-.landing-nav {
-  height: 0px;
-}
+// .landing-nav {
+//   height: 0px;
+// }
 
-.landing-nav img {
+.home-container .logo {
   height: 300px;
-  margin-left: 250px;
-  margin-top: 155px;
+  // margin-left: 250px;
+  // margin-top: 155px;
 }
 
-.index-search {
-  display: flex;
-}
+// .index-search {
+//   display: flex;
+// }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,12 +1,12 @@
-<div class="landing-nav">
-  <%= render "shared/landing_navbar" %>
-    <%= image_tag "shared/logo.png" %>
-</div>
+<%# <div class="landing-nav"> %>
+  <%# <%= render "shared/landing_navbar" %>
+<%# </div> %>
 
-<div class="home-container">
-  <%= image_tag "shared/landing_description.png" %>
+<div class="home-container d-flex flex-column justify-content-center align-items-center">
+  <%= image_tag "shared/logo.png", class: "logo p-2" %>
+  <%= image_tag "shared/landing_description.png", class: "description" %>
   <div class="landing-btns">
-    <%= link_to "List plant", new_plant_path, class: "pink-btn" %>
-    <%= link_to "Browse plants", plants_path, class: "pink-btn" %>
+    <%= link_to "List plant", new_plant_path, class: "pink-btn p-2" %>
+    <%= link_to "Browse plants", plants_path, class: "pink-btn p-2" %>
   </div>
 </div>


### PR DESCRIPTION
Changed background size to 100vh and some other fine tunning to work better with larger screens - still needs testing with the projector - It looked good in my 38in monitor and 15in laptop

Used boostrap flex to center logo and buttons

Used position relative/absolute to move description picture to top right - still needs testing with the projector

![image](https://user-images.githubusercontent.com/17050237/173196785-5385333d-2ae1-49bf-b21e-1f3855faaf54.png)
